### PR TITLE
add: logout API 개발용 게이트웨이 필터 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	implementation 'org.springframework.cloud:spring-cloud-config-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/kr/co/talk/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/talk/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package kr.co.talk.filter;
 
+import kr.co.talk.logout.service.LogoutRedisService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
@@ -19,12 +20,15 @@ public class JwtAuthenticationFilter
         extends AbstractGatewayFilterFactory<JwtAuthenticationFilter.Config> {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final LogoutRedisService logoutRedisService;
     private static final String USER_ID = "userId";
+    private static final String LOGOUT_PATH = "/user/logout";
 
     @Autowired
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, LogoutRedisService logoutRedisService) {
         super(Config.class);
         this.jwtTokenProvider = jwtTokenProvider;
+        this.logoutRedisService = logoutRedisService;
     }
 
     @Override
@@ -47,13 +51,16 @@ public class JwtAuthenticationFilter
             String token = authorizationHeader.split("Bearer ")[1].trim();
             log.info("token info :: {}", token);
 
+            // logout API에 적용된 액세스 토큰일 때
+            if (logoutRedisService.isBlockedAccessToken(token)) {
+                log.warn("This access token is blocked by logout API.");
+                return onError(exchange);
+            }
+
             // 토근 유효성 통과 안됐을시 예외 발생, userId 가져옴
             String subject = jwtTokenProvider.getAccessTokenSubject(token);
             log.info("subject:: {} ", subject);
 
-            // header에 userId 추가
-//            exchange.getRequest().mutate().header(USER_ID, subject);
-//            return chain.filter(exchange);
             ServerHttpRequest serverHttpRequest = exchange.getRequest().mutate()
                     .header(USER_ID, subject)
                     .build();
@@ -62,6 +69,12 @@ public class JwtAuthenticationFilter
                     .build();
             log.info("header USER_ID :: {}", webExchange.getRequest().getHeaders().get(USER_ID));
 
+            // 로그아웃 API일때 redis에 액세스토큰 블랙리스트 등록
+            if (request.getPath().toString().equals(LOGOUT_PATH)) {
+                long leftExpirationMillis = jwtTokenProvider.getLeftExpirationMillis(token);
+                logoutRedisService.blockAccessToken(token, leftExpirationMillis);
+            }
+
             return chain.filter(webExchange);
         };
     }
@@ -69,7 +82,7 @@ public class JwtAuthenticationFilter
 
     /**
      * 인증 실패 시, 권한 없음을 나타냄
-     * 
+     *
      * @param exchange
      * @param errorMsg
      * @param httpStatus
@@ -84,7 +97,6 @@ public class JwtAuthenticationFilter
         return response.setComplete();
 
     }
-
 
 
     static class Config {

--- a/src/main/java/kr/co/talk/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/talk/filter/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -70,7 +71,7 @@ public class JwtAuthenticationFilter
             log.info("header USER_ID :: {}", webExchange.getRequest().getHeaders().get(USER_ID));
 
             // 로그아웃 API일때 redis에 액세스토큰 블랙리스트 등록
-            if (request.getPath().toString().equals(LOGOUT_PATH)) {
+            if (request.getPath().toString().equals(LOGOUT_PATH) && request.getMethod() == HttpMethod.POST) {
                 long leftExpirationMillis = jwtTokenProvider.getLeftExpirationMillis(token);
                 logoutRedisService.blockAccessToken(token, leftExpirationMillis);
             }

--- a/src/main/java/kr/co/talk/logout/service/LogoutRedisService.java
+++ b/src/main/java/kr/co/talk/logout/service/LogoutRedisService.java
@@ -1,0 +1,45 @@
+package kr.co.talk.logout.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class LogoutRedisService {
+    private static final String LOGGED_OUT_USER_POSTFIX = "_LOGOUT_";
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 액세스 토큰을 블랙리스트로 저장
+     * @param accessToken 액세스 토큰
+     * @param millis 남은 유효기간 밀리세컨드
+     */
+    public void blockAccessToken(String accessToken, long millis) {
+        this.set(accessToken + LOGGED_OUT_USER_POSTFIX, millis / 1000);
+    }
+
+    /**
+     * 블랙리스트에 저장된 액세스 토큰인지 리턴
+     * @param accessToken 액세스 토큰
+     * @return 블랙리스트 등록되어 있으면 {@code true}
+     */
+    public boolean isBlockedAccessToken(String accessToken) {
+        return hasKey(accessToken + LOGGED_OUT_USER_POSTFIX);
+    }
+
+    private void set(String key, long seconds) {
+        redisTemplate.opsForValue().set(key, "", Duration.ofSeconds(seconds));
+        log.info("set redis value for {} sec\n{} : {}", seconds, key, "");
+    }
+
+    private boolean hasKey(String key) {
+        return redisTemplate.opsForValue().getOperations().hasKey(key) == Boolean.TRUE;
+    }
+
+}


### PR DESCRIPTION
로그아웃 진행 시

1. `POST /user/logout`
2. `apigateway.yml`에 따라 게이트웨이에서 `JwtAuthenticationFilter` 적용
3. `JwtAuthenticationFilter`에서 `/user/logout`일 경우에 redis에 액세스토큰 블랙리스트로 남은 유효기간동안 등록
4. filter chain에 의해 user-service로 인입
5. user-service에서는 redis에 저장된 리프레쉬 토큰 삭제